### PR TITLE
feat(compute): migrate backend from App Runner to ECS Fargate

### DIFF
--- a/dev-log/CONTEXT.md
+++ b/dev-log/CONTEXT.md
@@ -1,15 +1,18 @@
 # Project Context — ai-outbound-calling
 
-*Auto-generated at session end. Next AI should read this first.*
-*Last updated: 2026-03-05 01:03:28*
+*Auto-generated on commit. Last updated: 2026-03-05 02:58:14*
 
 ## Current State
 
-- **Branch**: `fix/#9-phone-number-quote-handling`
-- **Working on**: Issue #9 — phone number quote handling
+- **Branch**: `feature/#12-migrate-to-ecs-fargate`
+- **Working on**: Issue #12 — migrate to ecs fargate
 
 ## Uncommitted Changes
 
+**Unstaged:**
+```
+M	dev-log/CONTEXT.md
+```
 **Untracked:**
 ```
 dev-log/INDEX.md
@@ -17,30 +20,30 @@ dev-log/daily/2026-03-05.md
 dev-log/raw/2026-03-05-tools.log
 dev-log/raw/2026-03-05.log
 dev-log/sessions/2026-03-05_01-03-28.md
+dev-log/sessions/2026-03-05_01-56-11.md
+dev-log/sessions/2026-03-05_02-55-14.md
 ```
 
 ## Recent Commits (last 10)
 
 ```
+8758a3d feat(compute): migrate backend from App Runner to ECS Fargate
+da7161a Merge pull request #11 from LlechiKaito/fix/#9-phone-number-quote-handling
+a8372b4 modify: コンテキストドキュメントの更新
+27a3bc4 Merge pull request #10 from LlechiKaito/fix/#9-phone-number-quote-handling
 5d322fe chore(log): update dev-log
 6c6d7f3 fix(lead): strip all non-digit characters from phone numbers
 6437e43 Merge pull request #8 from LlechiKaito/feature/#4-auto-analyze-and-save
 c4fe444 refactor(config): separate SSM secrets from environment config
 45e0ec2 fix(infra): merge static and config deployments into single BucketDeployment
 2779eaf fix(infra): ensure config.js deploys after static files
-5df94d0 fix(infra): exclude config.js from static files deployment
-7790081 fix(deps): move @fastify/static to dependencies
-cc2e841 fix(infra): set Docker platform to linux/amd64 for App Runner
-a529d09 fix(config): support GOOGLE_CREDENTIALS_JSON for App Runner deployment
 ```
 
 ## Recent Sessions (last 3)
 
-- 2026-03-05_01-03-28: Fix #9: phone number quote handling (commits:0, unstaged:0 staged:0 untracked:2)
-- 2026-03-03_02-15-43: Overview (commits:0, no changes)
-  No commits during this session.
-- 2026-03-03_02-11-16: Overview (commits:0, no changes)
-  No commits during this session.
+- 2026-03-05_02-55-14: Feature #12: migrate to ecs fargate (commits:0)
+- 2026-03-05_01-56-11: Development (develop branch) (commits:0)
+- 2026-03-05_01-03-28: Fix #9: phone number quote handling (commits:0)
 
 ## Directory Structure (depth 2)
 

--- a/dev-log/INDEX.md
+++ b/dev-log/INDEX.md
@@ -1,0 +1,31 @@
+# Dev Log — ai-outbound-calling
+
+*Auto-generated. Last updated: 2026-03-05 02:55:14*
+
+## Daily Summaries
+
+- **2026-03-05** — 3 sessions, 0 commits ([detail](daily/2026-03-05.md))
+
+## Recent Sessions
+
+- **2026-03-05_02-55-14** — Feature #12: migrate to ecs fargate (0 commits) ([detail](sessions/2026-03-05_02-55-14.md))
+- **2026-03-05_01-56-11** — Development (develop branch) (0 commits) ([detail](sessions/2026-03-05_01-56-11.md))
+- **2026-03-05_01-03-28** — Fix #9: phone number quote handling (0 commits) ([detail](sessions/2026-03-05_01-03-28.md))
+- **2026-03-03_02-15-43** — Overview (0 commits) ([detail](sessions/2026-03-03_02-15-43.md))
+- **2026-03-03_02-11-16** — Overview (0 commits) ([detail](sessions/2026-03-03_02-11-16.md))
+- **2026-03-03_02-04-17** — Overview (0 commits) ([detail](sessions/2026-03-03_02-04-17.md))
+- **2026-03-03_01-42-36** — Overview (0 commits) ([detail](sessions/2026-03-03_01-42-36.md))
+- **2026-03-03_01-40-29** — Overview (0 commits) ([detail](sessions/2026-03-03_01-40-29.md))
+- **2026-03-03_01-39-35** — Overview (0 commits) ([detail](sessions/2026-03-03_01-39-35.md))
+- **2026-03-03_01-38-37** — Overview (0 commits) ([detail](sessions/2026-03-03_01-38-37.md))
+- **2026-03-03_01-37-18** — Overview (0 commits) ([detail](sessions/2026-03-03_01-37-18.md))
+- **2026-03-02_15-56-01** — Overview (0 commits) ([detail](sessions/2026-03-02_15-56-01.md))
+- **2026-03-02_15-50-17** — Overview (0 commits) ([detail](sessions/2026-03-02_15-50-17.md))
+- **2026-03-02_15-28-54** — Overview (0 commits) ([detail](sessions/2026-03-02_15-28-54.md))
+- **2026-03-02_15-28-04** — Overview (0 commits) ([detail](sessions/2026-03-02_15-28-04.md))
+- **2026-03-02_15-27-29** — Overview (0 commits) ([detail](sessions/2026-03-02_15-27-29.md))
+- **2026-03-02_15-19-59** — Overview (0 commits) ([detail](sessions/2026-03-02_15-19-59.md))
+- **2026-03-02_15-11-22** — Overview (0 commits) ([detail](sessions/2026-03-02_15-11-22.md))
+- **2026-03-02_15-07-40** — Overview (0 commits) ([detail](sessions/2026-03-02_15-07-40.md))
+- **2026-03-02_15-06-00** — Overview (0 commits) ([detail](sessions/2026-03-02_15-06-00.md))
+

--- a/dev-log/daily/2026-03-05.md
+++ b/dev-log/daily/2026-03-05.md
@@ -1,0 +1,20 @@
+# 2026-03-05 — ai-outbound-calling
+
+| Metric | Value |
+|--------|-------|
+| Sessions | 3 |
+| Total commits | 0 |
+| Total commands | 174 |
+| Total file ops | 441 |
+| Errors | 0 |
+
+## Sessions
+
+1. **01:03:28** — Fix #9: phone number quote handling (00:45:19 〜 01:02:58)
+2. **01:56:11** — Development (develop branch) (00:45:19 〜 01:49:02)
+3. **02:55:14** — Feature #12: migrate to ecs fargate (00:45:19 〜 02:54:41)
+
+## Pending
+
+- Uncommitted changes: 3 unstaged, 0 staged, 2 untracked
+

--- a/dev-log/sessions/2026-03-05_01-03-28.md
+++ b/dev-log/sessions/2026-03-05_01-03-28.md
@@ -1,0 +1,26 @@
+# Session: 2026-03-05 01:03:28
+
+## Fix #9: phone number quote handling
+
+| Item | Value |
+|------|-------|
+| Session ID | `fa990b70-cece-4e7f-b691-4339e3da1c9f` |
+| Branch | `fix/#9-phone-number-quote-handling` |
+| Duration | 00:45:19 〜 01:02:58 |
+| Bash commands | 36 (errors: 0
+0) |
+| File ops | 70 (R:38 E:4 W:0
+0 G:5 Gl:9) |
+| Commits | 0 |
+| Changes | unstaged:0 staged:0 untracked:2 |
+
+## Changed Files
+
+**Untracked:**
+```
+dev-log/raw/2026-03-05-tools.log
+dev-log/raw/2026-03-05.log
+```
+
+---
+*Raw logs: `dev-log/raw/2026-03-05.log`, `dev-log/raw/2026-03-05-tools.log`*

--- a/dev-log/sessions/2026-03-05_01-56-11.md
+++ b/dev-log/sessions/2026-03-05_01-56-11.md
@@ -1,0 +1,29 @@
+# Session: 2026-03-05 01:56:11
+
+## Development (develop branch)
+
+| Item | Value |
+|------|-------|
+| Session ID | `ac0c2e67-f4bf-4e5e-86ab-2d572f8b2070` |
+| Branch | `develop` |
+| Duration | 00:45:19 〜 01:49:02 |
+| Bash commands | 47 (errors: 0
+0) |
+| File ops | 127 (R:65 E:4 W:0
+0 G:8 Gl:16) |
+| Commits | 0 |
+| Changes | unstaged:0 staged:0 untracked:5 |
+
+## Changed Files
+
+**Untracked:**
+```
+dev-log/INDEX.md
+dev-log/daily/2026-03-05.md
+dev-log/raw/2026-03-05-tools.log
+dev-log/raw/2026-03-05.log
+dev-log/sessions/2026-03-05_01-03-28.md
+```
+
+---
+*Raw logs: `dev-log/raw/2026-03-05.log`, `dev-log/raw/2026-03-05-tools.log`*

--- a/dev-log/sessions/2026-03-05_02-55-14.md
+++ b/dev-log/sessions/2026-03-05_02-55-14.md
@@ -1,0 +1,32 @@
+# Session: 2026-03-05 02:55:14
+
+## Feature #12: migrate to ecs fargate
+
+| Item | Value |
+|------|-------|
+| Session ID | `339d80e0-b165-4c9b-b69c-d40eb95757af` |
+| Branch | `feature/#12-migrate-to-ecs-fargate` |
+| Duration | 00:45:19 〜 02:54:41 |
+| Bash commands | 91 (errors: 0
+0) |
+| File ops | 244 (R:101 E:23 W:3 G:9 Gl:18) |
+| Commits | 0 |
+| Changes | unstaged:3 staged:0 untracked:2 |
+
+## Changed Files
+
+**Unstaged:**
+```
+M	dev-log/CONTEXT.md
+M	infra/config/environments.ts
+M	infra/lib/compute/compute.ts
+```
+
+**Untracked:**
+```
+lib/compute/constants.ts
+lib/compute/env-builder.ts
+```
+
+---
+*Raw logs: `dev-log/raw/2026-03-05.log`, `dev-log/raw/2026-03-05-tools.log`*

--- a/infra/config/environments.ts
+++ b/infra/config/environments.ts
@@ -1,8 +1,9 @@
 export interface EnvironmentConfig {
   readonly envName: string;
   readonly backendPort: number;
-  readonly backendCpu: string;
-  readonly backendMemory: string;
+  readonly backendCpu: number;
+  readonly backendMemory: number;
+  readonly desiredCount: number;
   readonly skipBusinessHoursCheck: boolean;
 
   // Feature flags
@@ -22,8 +23,9 @@ export const ENVIRONMENTS: Record<string, EnvironmentConfig> = {
   dev: {
     envName: "dev",
     backendPort: 3000,
-    backendCpu: "0.25 vCPU",
-    backendMemory: "0.5 GB",
+    backendCpu: 256,
+    backendMemory: 512,
+    desiredCount: 1,
     skipBusinessHoursCheck: true,
     enableGoogle: true,
     enableElevenLabs: true,
@@ -35,8 +37,9 @@ export const ENVIRONMENTS: Record<string, EnvironmentConfig> = {
   prod: {
     envName: "prod",
     backendPort: 3000,
-    backendCpu: "0.5 vCPU",
-    backendMemory: "1 GB",
+    backendCpu: 512,
+    backendMemory: 1024,
+    desiredCount: 1,
     skipBusinessHoursCheck: false,
     enableGoogle: true,
     enableElevenLabs: true,

--- a/infra/lib/compute/compute.ts
+++ b/infra/lib/compute/compute.ts
@@ -1,17 +1,34 @@
 import * as path from "node:path";
 
 import * as cdk from "aws-cdk-lib";
-import * as apprunner from "aws-cdk-lib/aws-apprunner";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecr_assets from "aws-cdk-lib/aws-ecr-assets";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as logs from "aws-cdk-lib/aws-logs";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 
 import { EnvironmentConfig } from "../../config/environments";
-
-type KeyValuePair = apprunner.CfnService.KeyValuePairProperty;
-
-const HEALTH_CHECK_PATH = "/health";
+import { buildEnvVars, buildSsmSecrets } from "./env-builder";
+import {
+  ALB_PORT,
+  CONTAINER_NAME,
+  HEALTHY_THRESHOLD_COUNT,
+  HEALTH_CHECK_INTERVAL_SECONDS,
+  HEALTH_CHECK_PATH,
+  HEALTH_CHECK_RETRIES,
+  HEALTH_CHECK_START_PERIOD_SECONDS,
+  HEALTH_CHECK_TIMEOUT_SECONDS,
+  MAX_AZS,
+  MAX_HEALTHY_PERCENT,
+  MIN_HEALTHY_PERCENT,
+  NAT_GATEWAYS_DEV,
+  NAT_GATEWAYS_PROD,
+  SUBNET_CIDR_MASK,
+  UNHEALTHY_THRESHOLD_COUNT,
+} from "./constants";
 
 interface ComputeConstructProps {
   readonly envConfig: EnvironmentConfig;
@@ -27,22 +44,111 @@ export class ComputeConstruct extends Construct {
     const { envConfig } = props;
     const ssmPrefix = `/ai-outbound-calling/${envConfig.envName}`;
 
-    const image = new ecr_assets.DockerImageAsset(this, "BackendImage", {
+    const vpc = this.createVpc(envConfig);
+    const cluster = this.createCluster(envConfig, vpc);
+    const image = this.createDockerImage();
+    const taskDefinition = this.createTaskDefinition(
+      stack,
+      envConfig,
+      ssmPrefix,
+      image,
+    );
+    const { service, alb } = this.createService(
+      envConfig,
+      cluster,
+      taskDefinition,
+      vpc,
+    );
+
+    const albUrl = `http://${alb.loadBalancerDnsName}`;
+    this.serviceUrl = albUrl;
+
+    new ssm.StringParameter(this, "PublicUrlParam", {
+      parameterName: `${ssmPrefix}/PUBLIC_URL`,
+      stringValue: albUrl,
+    });
+
+    new cdk.CfnOutput(stack, "BackendUrl", {
+      value: albUrl,
+      description: "ALB URL for backend service",
+    });
+  }
+
+  private createVpc(envConfig: EnvironmentConfig): ec2.Vpc {
+    return new ec2.Vpc(this, "Vpc", {
+      maxAzs: MAX_AZS,
+      natGateways:
+        envConfig.envName === "prod" ? NAT_GATEWAYS_PROD : NAT_GATEWAYS_DEV,
+      subnetConfiguration: [
+        {
+          name: "Public",
+          subnetType: ec2.SubnetType.PUBLIC,
+          cidrMask: SUBNET_CIDR_MASK,
+        },
+        {
+          name: "Private",
+          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+          cidrMask: SUBNET_CIDR_MASK,
+        },
+      ],
+    });
+  }
+
+  private createCluster(
+    envConfig: EnvironmentConfig,
+    vpc: ec2.Vpc,
+  ): ecs.Cluster {
+    return new ecs.Cluster(this, "Cluster", {
+      clusterName: `ai-outbound-calling-${envConfig.envName}`,
+      vpc,
+      containerInsightsV2:
+        envConfig.envName === "prod"
+          ? ecs.ContainerInsights.ENABLED
+          : ecs.ContainerInsights.DISABLED,
+    });
+  }
+
+  private createDockerImage(): ecr_assets.DockerImageAsset {
+    return new ecr_assets.DockerImageAsset(this, "BackendImage", {
       directory: path.join(__dirname, "..", "..", ".."),
       file: "Dockerfile",
       target: "prod",
       platform: ecr_assets.Platform.LINUX_AMD64,
     });
+  }
 
-    const accessRole = new iam.Role(this, "AccessRole", {
-      assumedBy: new iam.ServicePrincipal("build.apprunner.amazonaws.com"),
-    });
-    image.repository.grantPull(accessRole);
+  private createTaskDefinition(
+    stack: cdk.Stack,
+    envConfig: EnvironmentConfig,
+    ssmPrefix: string,
+    image: ecr_assets.DockerImageAsset,
+  ): ecs.FargateTaskDefinition {
+    const taskDefinition = new ecs.FargateTaskDefinition(
+      this,
+      "TaskDefinition",
+      {
+        cpu: envConfig.backendCpu,
+        memoryLimitMiB: envConfig.backendMemory,
+      },
+    );
 
-    const instanceRole = new iam.Role(this, "InstanceRole", {
-      assumedBy: new iam.ServicePrincipal("tasks.apprunner.amazonaws.com"),
-    });
-    instanceRole.addToPolicy(
+    this.grantSsmAccess(taskDefinition, stack, ssmPrefix);
+
+    const logGroup = this.createLogGroup(envConfig);
+    const envVars = buildEnvVars(envConfig);
+    const ssmSecrets = buildSsmSecrets(this, stack, ssmPrefix, envConfig);
+
+    this.addContainer(taskDefinition, envConfig, image, logGroup, envVars, ssmSecrets);
+
+    return taskDefinition;
+  }
+
+  private grantSsmAccess(
+    taskDefinition: ecs.FargateTaskDefinition,
+    stack: cdk.Stack,
+    ssmPrefix: string,
+  ): void {
+    taskDefinition.taskRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         actions: ["ssm:GetParameters"],
         resources: [
@@ -50,126 +156,148 @@ export class ComputeConstruct extends Construct {
         ],
       }),
     );
+  }
 
-    const envVars = this.buildEnvVars(envConfig);
-    const ssmSecrets = this.buildSsmSecrets(stack, ssmPrefix, envConfig);
-
-    // L1 (CfnService) を使用: App Runner L2 は alpha のため
-    const service = new apprunner.CfnService(this, "Service", {
-      serviceName: `ai-outbound-calling-${envConfig.envName}`,
-      sourceConfiguration: {
-        imageRepository: {
-          imageIdentifier: image.imageUri,
-          imageRepositoryType: "ECR",
-          imageConfiguration: {
-            port: String(envConfig.backendPort),
-            runtimeEnvironmentVariables: envVars,
-            runtimeEnvironmentSecrets: ssmSecrets,
-          },
-        },
-        authenticationConfiguration: {
-          accessRoleArn: accessRole.roleArn,
-        },
-        autoDeploymentsEnabled: false,
-      },
-      instanceConfiguration: {
-        cpu: envConfig.backendCpu,
-        memory: envConfig.backendMemory,
-        instanceRoleArn: instanceRole.roleArn,
-      },
-      healthCheckConfiguration: {
-        protocol: "HTTP",
-        path: HEALTH_CHECK_PATH,
-      },
-    });
-
-    this.serviceUrl = cdk.Fn.join("", ["https://", service.attrServiceUrl]);
-
-    // App Runner の URL を SSM に自動書き込み（手動設定不要にする）
-    new ssm.StringParameter(this, "PublicUrlParam", {
-      parameterName: `${ssmPrefix}/PUBLIC_URL`,
-      stringValue: this.serviceUrl,
-    });
-
-    new cdk.CfnOutput(stack, "BackendUrl", {
-      value: this.serviceUrl,
-      description: "App Runner service URL",
+  private createLogGroup(envConfig: EnvironmentConfig): logs.LogGroup {
+    return new logs.LogGroup(this, "LogGroup", {
+      logGroupName: `/ecs/ai-outbound-calling-${envConfig.envName}`,
+      retention:
+        envConfig.envName === "prod"
+          ? logs.RetentionDays.ONE_MONTH
+          : logs.RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
   }
 
-  private buildEnvVars(envConfig: EnvironmentConfig): KeyValuePair[] {
-    const vars: KeyValuePair[] = [
-      { name: "PORT", value: String(envConfig.backendPort) },
-      { name: "HOST", value: "0.0.0.0" },
-      { name: "SKIP_BUSINESS_HOURS_CHECK", value: String(envConfig.skipBusinessHoursCheck) },
-    ];
-
-    if (envConfig.enableElevenLabs && envConfig.elevenLabsLanguage) {
-      vars.push({ name: "ELEVENLABS_LANGUAGE", value: envConfig.elevenLabsLanguage });
-    }
-
-    if (envConfig.enableMail) {
-      if (envConfig.mailHost) {
-        vars.push({ name: "MAIL_HOST", value: envConfig.mailHost });
-      }
-      if (envConfig.mailPort) {
-        vars.push({ name: "MAIL_PORT", value: envConfig.mailPort });
-      }
-    }
-
-    return vars;
-  }
-
-  /**
-   * SSM には機密情報のみ格納する。
-   * PUBLIC_URL は App Runner 自身の URL を参照するため循環依存になり、
-   * CDK で自動解決できないので SSM に残す。
-   */
-  private buildSsmSecrets(
-    stack: cdk.Stack,
-    ssmPrefix: string,
+  private addContainer(
+    taskDefinition: ecs.FargateTaskDefinition,
     envConfig: EnvironmentConfig,
-  ): KeyValuePair[] {
-    const toArn = (name: string): string =>
-      `arn:aws:ssm:${stack.region}:${stack.account}:parameter${ssmPrefix}/${name}`;
-
-    const secrets: KeyValuePair[] = [
-      "PUBLIC_URL",
-      "TWILIO_ACCOUNT_SID",
-      "TWILIO_AUTH_TOKEN",
-      "TWILIO_PHONE_NUMBER",
-      "OPENAI_API_KEY",
-      "CALL_COMPANY_NAME",
-      "CALL_CONTACT_NAME",
-    ].map((name) => ({ name, value: toArn(name) }));
-
-    if (envConfig.enableGoogle) {
-      secrets.push(
-        ...["GOOGLE_SHEETS_ID", "GOOGLE_CREDENTIALS_JSON"].map((name) => ({
-          name,
-          value: toArn(name),
-        })),
-      );
-    }
-
-    if (envConfig.enableElevenLabs) {
-      secrets.push(
-        ...["ELEVENLABS_API_KEY", "ELEVENLABS_AGENT_ID"].map((name) => ({
-          name,
-          value: toArn(name),
-        })),
-      );
-    }
-
-    if (envConfig.enableMail) {
-      secrets.push(
-        ...["MAIL_PASSWORD", "MAIL_USER", "MAIL_FROM"].map((name) => ({
-          name,
-          value: toArn(name),
-        })),
-      );
-    }
-
-    return secrets;
+    image: ecr_assets.DockerImageAsset,
+    logGroup: logs.LogGroup,
+    envVars: Record<string, string>,
+    ssmSecrets: Record<string, ecs.Secret>,
+  ): void {
+    taskDefinition.addContainer(CONTAINER_NAME, {
+      image: ecs.ContainerImage.fromDockerImageAsset(image),
+      portMappings: [
+        {
+          containerPort: envConfig.backendPort,
+          protocol: ecs.Protocol.TCP,
+        },
+      ],
+      environment: envVars,
+      secrets: ssmSecrets,
+      logging: ecs.LogDrivers.awsLogs({
+        streamPrefix: "backend",
+        logGroup,
+      }),
+      healthCheck: {
+        command: [
+          "CMD-SHELL",
+          `node -e "const http = require('http'); const req = http.get('http://localhost:${envConfig.backendPort}${HEALTH_CHECK_PATH}', (res) => { process.exit(res.statusCode === 200 ? 0 : 1); }); req.on('error', () => process.exit(1));"`,
+        ],
+        interval: cdk.Duration.seconds(HEALTH_CHECK_INTERVAL_SECONDS),
+        timeout: cdk.Duration.seconds(HEALTH_CHECK_TIMEOUT_SECONDS),
+        retries: HEALTH_CHECK_RETRIES,
+        startPeriod: cdk.Duration.seconds(HEALTH_CHECK_START_PERIOD_SECONDS),
+      },
+    });
   }
+
+  private createSecurityGroups(
+    vpc: ec2.Vpc,
+    backendPort: number,
+  ): { albSg: ec2.SecurityGroup; serviceSg: ec2.SecurityGroup } {
+    const albSg = new ec2.SecurityGroup(this, "AlbSg", {
+      vpc,
+      description: "Security group for ALB",
+      allowAllOutbound: true,
+    });
+    albSg.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(ALB_PORT),
+      "Allow HTTP from internet",
+    );
+
+    const serviceSg = new ec2.SecurityGroup(this, "ServiceSg", {
+      vpc,
+      description: "Security group for ECS Fargate service",
+      allowAllOutbound: true,
+    });
+    serviceSg.addIngressRule(
+      albSg,
+      ec2.Port.tcp(backendPort),
+      "Allow traffic from ALB only",
+    );
+
+    return { albSg, serviceSg };
+  }
+
+  private createAlb(
+    vpc: ec2.Vpc,
+    albSg: ec2.SecurityGroup,
+    backendPort: number,
+  ): { alb: elbv2.ApplicationLoadBalancer; targetGroup: elbv2.ApplicationTargetGroup } {
+    const alb = new elbv2.ApplicationLoadBalancer(this, "Alb", {
+      vpc,
+      internetFacing: true,
+      securityGroup: albSg,
+    });
+
+    const targetGroup = new elbv2.ApplicationTargetGroup(this, "TargetGroup", {
+      vpc,
+      port: backendPort,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      targetType: elbv2.TargetType.IP,
+      healthCheck: {
+        path: HEALTH_CHECK_PATH,
+        interval: cdk.Duration.seconds(HEALTH_CHECK_INTERVAL_SECONDS),
+        timeout: cdk.Duration.seconds(HEALTH_CHECK_TIMEOUT_SECONDS),
+        healthyThresholdCount: HEALTHY_THRESHOLD_COUNT,
+        unhealthyThresholdCount: UNHEALTHY_THRESHOLD_COUNT,
+      },
+    });
+
+    alb.addListener("HttpListener", {
+      port: ALB_PORT,
+      defaultTargetGroups: [targetGroup],
+    });
+
+    return { alb, targetGroup };
+  }
+
+  private createService(
+    envConfig: EnvironmentConfig,
+    cluster: ecs.Cluster,
+    taskDefinition: ecs.FargateTaskDefinition,
+    vpc: ec2.Vpc,
+  ): { service: ecs.FargateService; alb: elbv2.ApplicationLoadBalancer } {
+    const { albSg, serviceSg } = this.createSecurityGroups(
+      vpc,
+      envConfig.backendPort,
+    );
+
+    const { alb, targetGroup } = this.createAlb(
+      vpc,
+      albSg,
+      envConfig.backendPort,
+    );
+
+    const service = new ecs.FargateService(this, "Service", {
+      serviceName: `ai-outbound-calling-${envConfig.envName}`,
+      cluster,
+      taskDefinition,
+      desiredCount: envConfig.desiredCount,
+      minHealthyPercent: MIN_HEALTHY_PERCENT,
+      maxHealthyPercent: MAX_HEALTHY_PERCENT,
+      securityGroups: [serviceSg],
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      assignPublicIp: false,
+    });
+
+    service.attachToApplicationTargetGroup(targetGroup);
+
+    return { service, alb };
+  }
+
 }

--- a/infra/lib/compute/constants.ts
+++ b/infra/lib/compute/constants.ts
@@ -1,0 +1,15 @@
+export const HEALTH_CHECK_PATH = "/health";
+export const CONTAINER_NAME = "backend";
+export const ALB_PORT = 80;
+export const HEALTH_CHECK_INTERVAL_SECONDS = 30;
+export const HEALTH_CHECK_TIMEOUT_SECONDS = 5;
+export const HEALTH_CHECK_RETRIES = 3;
+export const HEALTH_CHECK_START_PERIOD_SECONDS = 60;
+export const HEALTHY_THRESHOLD_COUNT = 2;
+export const UNHEALTHY_THRESHOLD_COUNT = 3;
+export const MIN_HEALTHY_PERCENT = 100;
+export const MAX_HEALTHY_PERCENT = 200;
+export const SUBNET_CIDR_MASK = 24;
+export const MAX_AZS = 2;
+export const NAT_GATEWAYS_PROD = 2;
+export const NAT_GATEWAYS_DEV = 1;

--- a/infra/lib/compute/env-builder.ts
+++ b/infra/lib/compute/env-builder.ts
@@ -1,0 +1,75 @@
+import * as cdk from "aws-cdk-lib";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as ssm from "aws-cdk-lib/aws-ssm";
+import { Construct } from "constructs";
+
+import { EnvironmentConfig } from "../../config/environments";
+
+export function buildEnvVars(
+  envConfig: EnvironmentConfig,
+): Record<string, string> {
+  const vars: Record<string, string> = {
+    PORT: String(envConfig.backendPort),
+    HOST: "0.0.0.0",
+    SKIP_BUSINESS_HOURS_CHECK: String(envConfig.skipBusinessHoursCheck),
+  };
+
+  if (envConfig.enableElevenLabs && envConfig.elevenLabsLanguage) {
+    vars.ELEVENLABS_LANGUAGE = envConfig.elevenLabsLanguage;
+  }
+
+  if (envConfig.enableMail) {
+    if (envConfig.mailHost) {
+      vars.MAIL_HOST = envConfig.mailHost;
+    }
+    if (envConfig.mailPort) {
+      vars.MAIL_PORT = envConfig.mailPort;
+    }
+  }
+
+  return vars;
+}
+
+export function buildSsmSecrets(
+  scope: Construct,
+  stack: cdk.Stack,
+  ssmPrefix: string,
+  envConfig: EnvironmentConfig,
+): Record<string, ecs.Secret> {
+  const fromSsm = (name: string): ecs.Secret =>
+    ecs.Secret.fromSsmParameter(
+      ssm.StringParameter.fromStringParameterName(
+        scope,
+        `Ssm${name}`,
+        `${ssmPrefix}/${name}`,
+      ),
+    );
+
+  const secrets: Record<string, ecs.Secret> = {
+    PUBLIC_URL: fromSsm("PUBLIC_URL"),
+    TWILIO_ACCOUNT_SID: fromSsm("TWILIO_ACCOUNT_SID"),
+    TWILIO_AUTH_TOKEN: fromSsm("TWILIO_AUTH_TOKEN"),
+    TWILIO_PHONE_NUMBER: fromSsm("TWILIO_PHONE_NUMBER"),
+    OPENAI_API_KEY: fromSsm("OPENAI_API_KEY"),
+    CALL_COMPANY_NAME: fromSsm("CALL_COMPANY_NAME"),
+    CALL_CONTACT_NAME: fromSsm("CALL_CONTACT_NAME"),
+  };
+
+  if (envConfig.enableGoogle) {
+    secrets.GOOGLE_SHEETS_ID = fromSsm("GOOGLE_SHEETS_ID");
+    secrets.GOOGLE_CREDENTIALS_JSON = fromSsm("GOOGLE_CREDENTIALS_JSON");
+  }
+
+  if (envConfig.enableElevenLabs) {
+    secrets.ELEVENLABS_API_KEY = fromSsm("ELEVENLABS_API_KEY");
+    secrets.ELEVENLABS_AGENT_ID = fromSsm("ELEVENLABS_AGENT_ID");
+  }
+
+  if (envConfig.enableMail) {
+    secrets.MAIL_PASSWORD = fromSsm("MAIL_PASSWORD");
+    secrets.MAIL_USER = fromSsm("MAIL_USER");
+    secrets.MAIL_FROM = fromSsm("MAIL_FROM");
+  }
+
+  return secrets;
+}


### PR DESCRIPTION
## Summary

バックエンドのコンピューティング基盤を AWS App Runner から ECS Fargate に移行。学習目的で ECS Fargate の構成を CDK で実装した。フロントエンド（S3 + CloudFront）は変更なし。

**Note: デプロイはまだ実施していない。`cdk synth` での CloudFormation テンプレート生成は検証済み。**

Closes #12

## Changes

- `infra/lib/compute/compute.ts`: App Runner (CfnService) を ECS Fargate に完全置換
  - VPC（パブリック/プライベートサブネット、NAT Gateway）
  - ALB（ヘルスチェック /health）
  - ECS Cluster（prod は Container Insights 有効）
  - Fargate Task Definition（SSM シークレット注入）
  - Fargate Service（プライベートサブネット配置、ALB 連携）
  - Security Groups（ALB → ECS のみ許可）
  - CloudWatch Logs（コンテナログ出力）
  - Node.js ベースのコンテナヘルスチェック（slim イメージに curl がないため）
- `infra/lib/compute/constants.ts`: 定数を分離（マジックナンバー排除）
- `infra/lib/compute/env-builder.ts`: 環境変数・SSM シークレットビルダーを分離
- `infra/config/environments.ts`: CPU/Memory を ECS Fargate 形式（数値）に変更、`desiredCount` 追加

## Untested Features

- **ECS Fargate デプロイ**: デプロイは実施していないため、実環境での動作は未検証
  - テスト済みの範囲: `cdk synth` による CloudFormation テンプレート生成、TypeScript コンパイル
  - 未テストの範囲: 実際の AWS リソース作成、ALB 経由の通信、SSM シークレット注入の実動作
- **既存テスト（Unit / Integration / E2E）**: コンテナ環境のメモリ制限により実行不可（今回の変更と無関係）

## Test Plan

1. `cd infra && npx tsc --noEmit` — TypeScript コンパイル成功
2. `npx cdk synth --context env=dev` — CloudFormation テンプレート生成成功（警告なし）
3. `npx cdk synth --context env=prod` — prod 環境でも生成成功
4. デプロイ時: `cdk diff --context env=dev` で差分確認 → `cdk deploy` は人間が実行

## Checklist

- [ ] ユニットテストを書いた（tests/unit/）— インフラ変更のみ、アプリコード変更なし
- [ ] インテグレーションテストを書いた（tests/integration/）— インフラ変更のみ
- [ ] E2E テストを Playwright で書いた（tests/e2e/）— インフラ変更のみ
- [x] 全テストが通る — cdk synth 成功、TypeScript コンパイル成功
- [ ] アプリを起動してブラウザで動作確認した — デプロイ未実施
- [x] Test Specifications にテスト一覧を記載した
- [x] `/review` でセルフレビューをパスした