### PR TITLE
feat(compute): remove NAT Gateway and use public subnet for Fargate

### DIFF
--- a/dev-log/CONTEXT.md
+++ b/dev-log/CONTEXT.md
@@ -1,32 +1,33 @@
 # Project Context — ai-outbound-calling
 
-*Auto-generated on commit. Last updated: 2026-03-05 02:58:14*
+*Auto-generated on commit. Last updated: 2026-03-05 03:41:22*
 
 ## Current State
 
-- **Branch**: `feature/#12-migrate-to-ecs-fargate`
-- **Working on**: Issue #12 — migrate to ecs fargate
+- **Branch**: `feature/#14-remove-nat-gateway`
+- **Working on**: Issue #14 — remove nat gateway
 
 ## Uncommitted Changes
 
 **Unstaged:**
 ```
 M	dev-log/CONTEXT.md
+M	dev-log/INDEX.md
+M	dev-log/daily/2026-03-05.md
 ```
 **Untracked:**
 ```
-dev-log/INDEX.md
-dev-log/daily/2026-03-05.md
 dev-log/raw/2026-03-05-tools.log
 dev-log/raw/2026-03-05.log
-dev-log/sessions/2026-03-05_01-03-28.md
-dev-log/sessions/2026-03-05_01-56-11.md
-dev-log/sessions/2026-03-05_02-55-14.md
+dev-log/sessions/2026-03-05_03-29-42.md
 ```
 
 ## Recent Commits (last 10)
 
 ```
+34e6575 feat(compute): remove NAT Gateway and use public subnet for Fargate
+dd90cf0 Merge pull request #13 from LlechiKaito/feature/#12-migrate-to-ecs-fargate
+72c353d chore(log): update dev-log
 8758a3d feat(compute): migrate backend from App Runner to ECS Fargate
 da7161a Merge pull request #11 from LlechiKaito/fix/#9-phone-number-quote-handling
 a8372b4 modify: コンテキストドキュメントの更新
@@ -34,16 +35,13 @@ a8372b4 modify: コンテキストドキュメントの更新
 5d322fe chore(log): update dev-log
 6c6d7f3 fix(lead): strip all non-digit characters from phone numbers
 6437e43 Merge pull request #8 from LlechiKaito/feature/#4-auto-analyze-and-save
-c4fe444 refactor(config): separate SSM secrets from environment config
-45e0ec2 fix(infra): merge static and config deployments into single BucketDeployment
-2779eaf fix(infra): ensure config.js deploys after static files
 ```
 
 ## Recent Sessions (last 3)
 
+- 2026-03-05_03-29-42: Development (develop branch) (commits:0)
 - 2026-03-05_02-55-14: Feature #12: migrate to ecs fargate (commits:0)
 - 2026-03-05_01-56-11: Development (develop branch) (commits:0)
-- 2026-03-05_01-03-28: Fix #9: phone number quote handling (commits:0)
 
 ## Directory Structure (depth 2)
 

--- a/dev-log/INDEX.md
+++ b/dev-log/INDEX.md
@@ -1,13 +1,14 @@
 # Dev Log — ai-outbound-calling
 
-*Auto-generated. Last updated: 2026-03-05 02:55:14*
+*Auto-generated. Last updated: 2026-03-05 03:29:43*
 
 ## Daily Summaries
 
-- **2026-03-05** — 3 sessions, 0 commits ([detail](daily/2026-03-05.md))
+- **2026-03-05** — 4 sessions, 0 commits ([detail](daily/2026-03-05.md))
 
 ## Recent Sessions
 
+- **2026-03-05_03-29-42** — Development (develop branch) (0 commits) ([detail](sessions/2026-03-05_03-29-42.md))
 - **2026-03-05_02-55-14** — Feature #12: migrate to ecs fargate (0 commits) ([detail](sessions/2026-03-05_02-55-14.md))
 - **2026-03-05_01-56-11** — Development (develop branch) (0 commits) ([detail](sessions/2026-03-05_01-56-11.md))
 - **2026-03-05_01-03-28** — Fix #9: phone number quote handling (0 commits) ([detail](sessions/2026-03-05_01-03-28.md))
@@ -27,5 +28,4 @@
 - **2026-03-02_15-19-59** — Overview (0 commits) ([detail](sessions/2026-03-02_15-19-59.md))
 - **2026-03-02_15-11-22** — Overview (0 commits) ([detail](sessions/2026-03-02_15-11-22.md))
 - **2026-03-02_15-07-40** — Overview (0 commits) ([detail](sessions/2026-03-02_15-07-40.md))
-- **2026-03-02_15-06-00** — Overview (0 commits) ([detail](sessions/2026-03-02_15-06-00.md))
 

--- a/dev-log/daily/2026-03-05.md
+++ b/dev-log/daily/2026-03-05.md
@@ -2,10 +2,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Sessions | 3 |
+| Sessions | 4 |
 | Total commits | 0 |
-| Total commands | 174 |
-| Total file ops | 441 |
+| Total commands | 282 |
+| Total file ops | 711 |
 | Errors | 0 |
 
 ## Sessions
@@ -13,8 +13,9 @@
 1. **01:03:28** — Fix #9: phone number quote handling (00:45:19 〜 01:02:58)
 2. **01:56:11** — Development (develop branch) (00:45:19 〜 01:49:02)
 3. **02:55:14** — Feature #12: migrate to ecs fargate (00:45:19 〜 02:54:41)
+4. **03:29:42** — Development (develop branch) (00:45:19 〜 03:28:14)
 
 ## Pending
 
-- Uncommitted changes: 3 unstaged, 0 staged, 2 untracked
+- Uncommitted changes: 0 unstaged, 0 staged, 2 untracked
 

--- a/dev-log/sessions/2026-03-05_03-29-42.md
+++ b/dev-log/sessions/2026-03-05_03-29-42.md
@@ -1,0 +1,25 @@
+# Session: 2026-03-05 03:29:42
+
+## Development (develop branch)
+
+| Item | Value |
+|------|-------|
+| Session ID | `eeaf4120-1898-4aee-907d-e870a337487d` |
+| Branch | `develop` |
+| Duration | 00:45:19 〜 03:28:14 |
+| Bash commands | 108 (errors: 0
+0) |
+| File ops | 270 (R:102 E:23 W:3 G:9 Gl:18) |
+| Commits | 0 |
+| Changes | unstaged:0 staged:0 untracked:2 |
+
+## Changed Files
+
+**Untracked:**
+```
+dev-log/raw/2026-03-05-tools.log
+dev-log/raw/2026-03-05.log
+```
+
+---
+*Raw logs: `dev-log/raw/2026-03-05.log`, `dev-log/raw/2026-03-05-tools.log`*

--- a/infra/lib/compute/compute.ts
+++ b/infra/lib/compute/compute.ts
@@ -24,8 +24,6 @@ import {
   MAX_AZS,
   MAX_HEALTHY_PERCENT,
   MIN_HEALTHY_PERCENT,
-  NAT_GATEWAYS_DEV,
-  NAT_GATEWAYS_PROD,
   SUBNET_CIDR_MASK,
   UNHEALTHY_THRESHOLD_COUNT,
 } from "./constants";
@@ -44,7 +42,7 @@ export class ComputeConstruct extends Construct {
     const { envConfig } = props;
     const ssmPrefix = `/ai-outbound-calling/${envConfig.envName}`;
 
-    const vpc = this.createVpc(envConfig);
+    const vpc = this.createVpc();
     const cluster = this.createCluster(envConfig, vpc);
     const image = this.createDockerImage();
     const taskDefinition = this.createTaskDefinition(
@@ -74,20 +72,14 @@ export class ComputeConstruct extends Construct {
     });
   }
 
-  private createVpc(envConfig: EnvironmentConfig): ec2.Vpc {
+  private createVpc(): ec2.Vpc {
     return new ec2.Vpc(this, "Vpc", {
       maxAzs: MAX_AZS,
-      natGateways:
-        envConfig.envName === "prod" ? NAT_GATEWAYS_PROD : NAT_GATEWAYS_DEV,
+      natGateways: 0,
       subnetConfiguration: [
         {
           name: "Public",
           subnetType: ec2.SubnetType.PUBLIC,
-          cidrMask: SUBNET_CIDR_MASK,
-        },
-        {
-          name: "Private",
-          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
           cidrMask: SUBNET_CIDR_MASK,
         },
       ],
@@ -291,8 +283,8 @@ export class ComputeConstruct extends Construct {
       minHealthyPercent: MIN_HEALTHY_PERCENT,
       maxHealthyPercent: MAX_HEALTHY_PERCENT,
       securityGroups: [serviceSg],
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
-      assignPublicIp: false,
+      vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+      assignPublicIp: true,
     });
 
     service.attachToApplicationTargetGroup(targetGroup);

--- a/infra/lib/compute/constants.ts
+++ b/infra/lib/compute/constants.ts
@@ -11,5 +11,3 @@ export const MIN_HEALTHY_PERCENT = 100;
 export const MAX_HEALTHY_PERCENT = 200;
 export const SUBNET_CIDR_MASK = 24;
 export const MAX_AZS = 2;
-export const NAT_GATEWAYS_PROD = 2;
-export const NAT_GATEWAYS_DEV = 1;


### PR DESCRIPTION
## Summary

NAT Gateway を廃止し、ECS Fargate を Public Subnet に配置することで月額 ~$32 のコスト削減を実現する。
セキュリティグループにより ALB からの 3000 番ポートのみ許可のため、セキュリティは維持される。

Closes #14

## Changes

- VPC から Private Subnet を削除し、Public Subnet のみに変更
- NAT Gateway を 0 に設定（`natGateways: 0`）
- Fargate Service を `PUBLIC` サブネットに配置、`assignPublicIp: true` に変更
- `constants.ts` から `NAT_GATEWAYS_DEV` / `NAT_GATEWAYS_PROD` を削除
- `createVpc()` から `envConfig` 引数を削除（環境依存の分岐が不要に）

## Untested Features

- **CDK インフラ変更**: バックエンドのビジネスロジック変更なし。CDK コードの検証は `cdk synth` で実施済み
  - テスト済みの範囲: `cdk synth` 成功、生成テンプレートに NAT Gateway なし、AssignPublicIp ENABLED を確認
  - 未テストの範囲: 実際のデプロイ（人間が `cdk deploy` で実行）

## Test Plan

1. `cd infra && npx cdk synth --context env=dev` → テンプレート生成成功
2. 生成テンプレートに `NATGateway` が含まれないことを確認
3. 生成テンプレートに `AssignPublicIp: ENABLED` が含まれることを確認
4. デプロイ後、ALB URL にアクセスして `/health` が 200 を返すことを確認

## Checklist

- [x] `/review` でセルフレビューをパスした
- [x] `cdk synth` が成功する
- [x] NAT Gateway 関連の定数が削除されている
- [x] セキュリティグループの設定は変更なし（ALB からのみ許可）
